### PR TITLE
Added support for GiantBomb's video player

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -54,6 +54,8 @@
 				<string>*.curiositystream.com</string>
 				<string>eurosportplayer.com</string>
 				<string>*.eurosportplayer.com</string>
+				<string>giantbomb.com</string>
+				<string>*.giantbomb.com</string>
 				<string>hulu.com</string>
 				<string>*.hulu.com</string>
 				<string>littlethings.com</string>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -363,6 +363,24 @@ const resources = {
     },
   },
 
+  'giantbomb': {
+    buttonElementType: 'div',
+    buttonParent: function() {
+      return document.querySelector('.av-controls--right');
+    },
+    buttonScale: 0.7,
+    buttonStyle: /** CSS */ (`
+      margin-left: 16px;
+      height: 100%;
+      opacity: 1.0;
+      cursor: pointer;
+    `),
+    videoElement: function() {
+      var video = document.getElementsByTagName('video')[0];
+      return video;
+    }
+  },
+
   'hulu': {
     buttonClassName: 'simple-button',
     buttonDidAppear: function() {


### PR DESCRIPTION
* Added (*.)giantbomb.com to allowed domains
* Added selectors for video player

<img width="706" alt="screen shot 2017-09-12 at 9 10 26 am" src="https://user-images.githubusercontent.com/401388/30327485-4013376e-979a-11e7-8085-ad901ec7951e.png">
